### PR TITLE
Make enable_client_secret work

### DIFF
--- a/lib/CatalystX/OAuth2/Controller/Role/Provider.pm
+++ b/lib/CatalystX/OAuth2/Controller/Role/Provider.pm
@@ -18,6 +18,12 @@ has $_ => (
 around create_action => sub {
   my $orig   = shift;
   my $self   = shift;
+  my $name   = {@_}->{name};
+  if ( $name =~ /(request|grant)/ ) {
+    my $action_config = $self->config->{action} && $self->config->{action}{$name};
+    push @_, (%$action_config) if $action_config;
+  }
+
   my $action = $self->$orig(@_);
   if (
     Moose::Util::does_role(

--- a/lib/CatalystX/OAuth2/Store/DBIC.pm
+++ b/lib/CatalystX/OAuth2/Store/DBIC.pm
@@ -59,8 +59,8 @@ sub create_client_code {
 sub find_client_code {
   my ( $self, $code, $id ) = @_;
   return $id
-    ? $self->_code_rs->find($code)
-    : $self->_code_rs($id)->find($code);
+    ? $self->_code_rs($id)->find($code)
+    : $self->_code_rs->find($code);
 }
 
 sub activate_client_code {

--- a/lib/CatalystX/OAuth2/Store/DBIC.pm
+++ b/lib/CatalystX/OAuth2/Store/DBIC.pm
@@ -117,7 +117,7 @@ sub find_code_from_refresh {
 sub verify_client_secret {
   my ( $self, $client_id, $access_secret ) = @_;
   my $client = $self->find_client($client_id);
-  return $client->client_secret eq $access_secret;
+  return ($client->client_secret||'') eq ($access_secret||'');
 }
 
 sub verify_client_token {

--- a/t/unit/200-actionrole-request-auth.t
+++ b/t/unit/200-actionrole-request-auth.t
@@ -65,6 +65,33 @@ my $mock = mock_context('AuthServer');
   is( $res->status,                     302 );
 }
 
+# Fail by not supplying a client_secret
+{
+  my $uri   = URI->new('/secret/request');
+  my $query = {
+    response_type => 'code',
+    client_id     => 1,
+    state         => 'bar',
+    redirect_uri  => 'http://localhost/auth',
+  };
+  $uri->query_form($query);
+  my $c = $mock->( GET $uri );
+  $c->dispatch;
+  is_deeply( $c->error, [], 'dispatches to request action cleanly' );
+  is( $c->res->body, undef, q{doesn't produce warning} );
+  ok( $c->req->can('oauth2'),
+    "installs oauth2 accessors if request is valid" );
+  ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
+  my $res    = $c->res;
+  ok( my $redirect = $c->req->oauth2->next_action_uri( $c->controller, $c ) );
+  is( $res->location, $redirect, 'redirects to the correct action' );
+  is_deeply( { $redirect->query_form }, {
+    error => 'unauthorized_client',
+	error_description => 'the client identified by 1 is not authorized to access this resource'
+    } )
+    or diag( Data::Dump::dump( $redirect->query_form ) );
+}
+
 {
   my $uri   = URI->new('/secret/request');
   my $query = {
@@ -74,7 +101,6 @@ my $mock = mock_context('AuthServer');
     redirect_uri  => 'http://localhost/auth',
     client_secret => 'foosecret'
   };
-
   $uri->query_form($query);
   my $c = $mock->( GET $uri );
   $c->dispatch;

--- a/t/unit/300-actionrole-grant-auth.t
+++ b/t/unit/300-actionrole-grant-auth.t
@@ -33,7 +33,6 @@ my $code =
     "installs oauth2 accessors if request is valid" );
   ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
   my $res    = $c->res;
-  my $client = $c->controller->store->find_client(1);
   isa_ok( my $oauth2 = $c->req->oauth2,
     'CatalystX::OAuth2::Request::GrantAuth' );
   my $redirect = $c->req->oauth2->next_action_uri( $c->controller, $c );
@@ -73,7 +72,6 @@ my $code =
     "installs oauth2 accessors if request is valid" );
   ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
   my $res    = $c->res;
-  my $client = $c->controller->store->find_client(1);
   isa_ok( my $oauth2 = $c->req->oauth2,
     'CatalystX::OAuth2::Request::GrantAuth' );
   my $redirect = $c->req->oauth2->next_action_uri( $c->controller, $c );
@@ -111,7 +109,6 @@ my $code =
     "installs oauth2 accessors if request is valid" );
   ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
   my $res    = $c->res;
-  my $client = $c->controller->store->find_client(1);
   isa_ok( my $oauth2 = $c->req->oauth2,
     'CatalystX::OAuth2::Request::GrantAuth' );
   ok( !$res->location );
@@ -141,7 +138,6 @@ my $code =
     "installs oauth2 accessors if request is valid" );
   ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
   my $res    = $c->res;
-  my $client = $c->controller->store->find_client(1);
   isa_ok( my $oauth2 = $c->req->oauth2,
     'CatalystX::OAuth2::Request::GrantAuth' );
   my $redirect = $c->req->oauth2->next_action_uri( $c->controller, $c );
@@ -219,7 +215,6 @@ my $code =
     "installs oauth2 accessors if request is valid" );
   ok( Moose::Util::does_role( $c->req, 'CatalystX::OAuth2::Request' ) );
   my $res    = $c->res;
-  my $client = $c->controller->store->find_client(1);
   isa_ok( my $oauth2 = $c->req->oauth2,
     'CatalystX::OAuth2::Request::GrantAuth' );
   my $redirect = $c->req->oauth2->next_action_uri( $c->controller, $c );

--- a/t/unit/300-actionrole-grant-auth.t
+++ b/t/unit/300-actionrole-grant-auth.t
@@ -158,7 +158,7 @@ my $code =
 }
 
 # try a grant with an incorrect client id
-# should redirect with access_denied
+# should redirect with unauthorized_client
 {
   my $uri = URI->new('/grant');
   $uri->query_form(


### PR DESCRIPTION
enable_client_secret and validate_client_secret doesn't appear to have worked in the past. validate_client_secret was never called because enable_client_secret was never loaded/respected out of the package config for the provider (verify_client_secret ... if $self->enable_client_secret in CatalystX::OAuth2::Request::RequestAuth). Fixed this by loading the config for the request/grant action roles - I think (but am not sure) that this was the intention, based on the config structure?

This patch requires my previous patch in order to work (https://github.com/perl-catalyst/CatalystX-OAuth2/pull/2). I'm not sure if I've done this correctly as the previous patch is included in the review - I created a new branch off my previous fix's branch, so it makes sense - but not sure if that's the correct flow.